### PR TITLE
レスポンスがnilの場合404になってしまうフィールドを除外する

### DIFF
--- a/lib/yao/resources/dumper/base.rb
+++ b/lib/yao/resources/dumper/base.rb
@@ -5,18 +5,28 @@ module Yao::Resources::Dumper
       @fields = v
     end
 
+    def self.bug_fields=(v)
+      @bug_fields = v
+    end
+
     def self.dump(obj)
       [obj].flatten.map do |o|
         arr = @fields.map{|field|
-          result = o.send(field)
+          # bugfixされるまで特定のメソッドは `_id` をつける
+          if @bug_fields.include?(field)
+            name = field + "_id"
+            [name, o.send("[]", name)]
+          else
+            result = o.send(field)
 
-          result = if result.instance_of?(Array)
-                    result.map{|r| resource_dump(r)}
-                   else
-                    resource_dump(result)
-                   end
+            result = if result.instance_of?(Array)
+                      result.map{|r| resource_dump(r)}
+                    else
+                      resource_dump(result)
+                    end
 
-          [field, result]
+            [field, result]
+          end
         }.flatten(1)
 
         Hash[*arr]

--- a/lib/yao/resources/dumper/loadbalancer.rb
+++ b/lib/yao/resources/dumper/loadbalancer.rb
@@ -8,5 +8,9 @@ module Yao::Resources::Dumper
       project vip_network vip_port vip_subnet listeners pools
     )
 
+    self.bug_fields = %w(
+      project vip_network vip_port vip_subnet
+    )
+    
   end
 end

--- a/lib/yao/resources/dumper/loadbalancer_listener.rb
+++ b/lib/yao/resources/dumper/loadbalancer_listener.rb
@@ -8,5 +8,9 @@ module Yao::Resources::Dumper
     
     )
 
+    self.bug_fields = %w(
+      project
+    )
+
   end
 end

--- a/lib/yao/resources/dumper/loadbalancer_pool.rb
+++ b/lib/yao/resources/dumper/loadbalancer_pool.rb
@@ -6,5 +6,9 @@ module Yao::Resources::Dumper
       session_persistence operating_status name
     )
 
+    self.bug_fields = %w(
+      project
+    )
+
   end
 end

--- a/lib/yao/resources/dumper/loadbalancer_pool_member.rb
+++ b/lib/yao/resources/dumper/loadbalancer_pool_member.rb
@@ -8,5 +8,9 @@ module Yao::Resources::Dumper
       project
     )
 
+    self.bug_fields = %w(
+      project
+    )
+
   end
 end


### PR DESCRIPTION
yaoにバグがありnilチェックをしていないフィールドを参照しようとするとエラーになる。
bugfixするまで回避する。